### PR TITLE
Fix critical audio bugs and add version display

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build script for Cloudflare Pages
+# Generates version.json from the latest git tag
+VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
+echo "{\"version\":\"$VERSION\"}" > version.json

--- a/index.html
+++ b/index.html
@@ -483,7 +483,14 @@
             <img src="https://licensebuttons.net/l/by-sa/4.0/80x15.png" alt="CC BY-SA 4.0" style="border:0;">
             CC BY-SA 4.0
         </a>
+        <br>
+        <span id="app-version" style="opacity:0.5;font-size:0.85em;margin-top:4px;display:inline-block;"></span>
     </footer>
+    <script>
+        fetch('version.json').then(r=>r.json()).then(d=>{
+            document.getElementById('app-version').textContent='v'+d.version;
+        }).catch(()=>{});
+    </script>
 
     <!-- Main Application Script -->
     <script type="module" src="js/app.js"></script>

--- a/js/audio/voice-manager.js
+++ b/js/audio/voice-manager.js
@@ -152,6 +152,28 @@ export function createVoice(frequency, velocity = 1) {
 }
 
 /**
+ * Fully disconnect and clean up all audio nodes in a voice
+ */
+function cleanupVoice(voice) {
+    voice.oscs.forEach(osc => {
+        try { osc.stop(); } catch(e) {}
+        try { osc.disconnect(); } catch(e) {}
+    });
+    voice.gains.forEach(g => {
+        try { g.disconnect(); } catch(e) {}
+    });
+    voice.lfoConnections.forEach(node => {
+        try { node.disconnect(); } catch(e) {}
+    });
+    try { noiseGain.disconnect(voice.filter); } catch(e) {}
+    try { voice.filter.disconnect(); } catch(e) {}
+    try { voice.vca.disconnect(); } catch(e) {}
+    voice.oscs = [];
+    voice.gains = [];
+    voice.lfoConnections = [];
+}
+
+/**
  * Release a voice with envelope release
  */
 export function releaseVoice(voice) {
@@ -167,11 +189,10 @@ export function releaseVoice(voice) {
     voice.filter.frequency.setValueAtTime(voice.filter.frequency.value, now);
     voice.filter.frequency.linearRampToValueAtTime(20, now + filterReleaseTime);
 
-    setTimeout(() => {
-        voice.oscs.forEach(osc => {
-            try { osc.stop(); } catch(e) {}
-        });
-    }, Math.max(releaseTime, filterReleaseTime) * 1000 + 100);
+    const cleanupDelay = Math.max(releaseTime, filterReleaseTime) * 1000 + 100;
+    voice._cleanupTimer = setTimeout(() => {
+        cleanupVoice(voice);
+    }, cleanupDelay);
 }
 
 /**
@@ -180,7 +201,15 @@ export function releaseVoice(voice) {
 export function noteOn(note, velocity = 1) {
     initAudio();
 
-    if (voices.has(note)) return;
+    // If same note is still releasing, force-cleanup the old voice immediately
+    if (voices.has(note)) {
+        const oldVoice = voices.get(note);
+        if (oldVoice._cleanupTimer) {
+            clearTimeout(oldVoice._cleanupTimer);
+        }
+        cleanupVoice(oldVoice);
+        voices.delete(note);
+    }
 
     // Record note if recording
     recordNoteOn(note);

--- a/js/ui/visualizations.js
+++ b/js/ui/visualizations.js
@@ -13,13 +13,19 @@ export function drawOscilloscope() {
     const width = canvas.width;
     const height = canvas.height;
 
+    let bufferLength = 0;
+    let dataArray = null;
+
     function draw() {
         requestAnimationFrame(draw);
 
         if (!analyser) return;
 
-        const bufferLength = analyser.frequencyBinCount;
-        const dataArray = new Uint8Array(bufferLength);
+        // Allocate buffer once, or reallocate if analyser changes
+        if (bufferLength !== analyser.frequencyBinCount) {
+            bufferLength = analyser.frequencyBinCount;
+            dataArray = new Uint8Array(bufferLength);
+        }
         analyser.getByteTimeDomainData(dataArray);
 
         ctx.fillStyle = '#001a00';

--- a/version.json
+++ b/version.json
@@ -1,0 +1,1 @@
+{"version":"dev"}


### PR DESCRIPTION
## Summary
- **Memory leak fix**: added `cleanupVoice()` that fully disconnects all audio nodes (oscillators, gains, LFO connections, noiseGain, filter, VCA) on voice release
- **Race condition fix**: `noteOn` now force-cleans old voice if same note is retriggered before release completes
- **GC pressure fix**: moved `Uint8Array` allocation outside `requestAnimationFrame` loop in oscilloscope
- **Version in footer**: reads from `version.json` generated by `build.sh` at deploy time (Cloudflare Pages)

## Test plan
- [ ] Play notes rapidly (same key) — no audio glitches or accumulation
- [ ] Long session with demo loops — check memory in DevTools (Performance Monitor)
- [ ] Verify oscilloscope still renders correctly
- [ ] Check footer shows version after deploy with `sh build.sh`