### PR TITLE
Add responsive mobile layout and fix oscilloscope

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -742,3 +742,217 @@ footer a {
 footer a:hover {
     text-decoration: underline;
 }
+
+/* ===== Mobile Layout ===== */
+@media (max-width: 600px) {
+    .header {
+        padding: 12px 10px;
+    }
+
+    .header h1 {
+        font-size: 1.5em;
+        letter-spacing: 4px;
+    }
+
+    .header p {
+        font-size: 0.7em;
+    }
+
+    /* Hide keyboard shortcuts info — not relevant on mobile */
+    .info-panel {
+        display: none;
+    }
+
+    /* Compact preset/demo buttons */
+    .preset-section {
+        gap: 6px;
+        padding: 8px;
+    }
+
+    .preset-btn {
+        padding: 6px 10px;
+        font-size: 0.75em;
+    }
+
+    .demo-section {
+        gap: 5px;
+        padding: 6px 8px;
+    }
+
+    .demo-btn {
+        padding: 5px 8px;
+        font-size: 0.7em;
+    }
+
+    .demo-label {
+        font-size: 0.7em;
+    }
+
+    .preset-manager {
+        gap: 5px;
+        padding: 6px 8px;
+    }
+
+    .preset-manager-label {
+        font-size: 0.75em;
+    }
+
+    .preset-manager-btn {
+        padding: 5px 8px;
+        font-size: 0.7em;
+    }
+
+    .preset-select {
+        min-width: 100px;
+        padding: 5px 8px;
+        font-size: 0.7em;
+    }
+
+    /* 2-column module grid */
+    .synth-container {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 6px;
+        padding: 6px;
+    }
+
+    .module {
+        padding: 6px 4px;
+        min-width: 0 !important;
+        overflow: hidden;
+    }
+
+    .module-title {
+        font-size: 0.65em;
+        margin-bottom: 6px;
+        letter-spacing: 1px;
+    }
+
+    /* Compact knobs for 2-col fit */
+    .knob {
+        width: 44px;
+        height: 44px;
+    }
+
+    .knob::after {
+        top: 5px;
+        width: 3px;
+        height: 14px;
+    }
+
+    .knob.small {
+        width: 36px;
+        height: 36px;
+    }
+
+    .knob.small::after {
+        top: 4px;
+        width: 2px;
+        height: 11px;
+    }
+
+    .knob-container {
+        margin: 4px 2px;
+    }
+
+    .knob-label {
+        font-size: 0.55em;
+        margin-top: 3px;
+    }
+
+    .knob-value {
+        font-size: 0.5em;
+    }
+
+    .knob-row {
+        gap: 0;
+    }
+
+    /* Compact wave selectors */
+    .wave-selector {
+        gap: 3px;
+        margin: 5px 0;
+    }
+
+    .wave-btn {
+        width: 28px;
+        height: 24px;
+    }
+
+    .wave-btn svg {
+        width: 16px;
+        height: 12px;
+    }
+
+    /* Compact LFO destination dropdown */
+    .slider-container {
+        margin: 5px;
+    }
+
+    .slider-container select {
+        font-size: 0.7em;
+        padding: 3px;
+    }
+
+    .slider-label {
+        font-size: 0.6em;
+    }
+
+    /* LED smaller */
+    .led {
+        width: 8px;
+        height: 8px;
+        margin: 3px auto;
+    }
+
+    /* Oscilloscope spans full width */
+    .oscilloscope {
+        grid-column: 1 / -1;
+        margin: 0;
+        padding: 6px;
+    }
+
+    /* ADSR canvas smaller */
+    canvas[id$="-env-display"] {
+        height: 40px;
+    }
+
+    /* Keyboard: scrollable, bigger keys */
+    .keyboard-container {
+        padding: 10px 0;
+        margin-top: 8px;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .keyboard {
+        height: 120px;
+        margin: 0;
+        padding: 0 10px 15px;
+    }
+
+    .white-key {
+        width: 36px;
+        height: 100px;
+    }
+
+    .white-key:active, .white-key.pressed {
+        height: 98px;
+    }
+
+    .black-key {
+        width: 24px;
+        height: 62px;
+    }
+
+    .black-key:active, .black-key.pressed {
+        height: 60px;
+    }
+
+    /* Footer compact */
+    footer {
+        padding: 10px;
+        font-size: 0.75em;
+        margin-top: 8px;
+    }
+}

--- a/js/audio/audio-context.js
+++ b/js/audio/audio-context.js
@@ -8,6 +8,7 @@ import {
     setNoiseNode, setNoiseGain,
     setLfo1Osc, setLfo1Gain, setLfo2Osc, setLfo2Gain
 } from '../state.js';
+import { drawOscilloscope } from '../ui/visualizations.js';
 
 /**
  * Create white noise generator
@@ -143,4 +144,6 @@ export function initAudio() {
     setLfo2Osc(lfo2OscNode);
     setLfo2Gain(lfo2GainNode);
 
+    // Start oscilloscope (runs continuously like a real scope)
+    drawOscilloscope();
 }

--- a/js/audio/voice-manager.js
+++ b/js/audio/voice-manager.js
@@ -6,7 +6,6 @@ import {
 } from '../state.js';
 import { initAudio } from './audio-context.js';
 import { recordNoteOn, recordNoteOff } from '../recorder/song-recorder.js';
-import { startScope, stopScope } from '../ui/visualizations.js';
 
 // Audio constants
 const OSC_GAIN_SCALE = 0.3;
@@ -217,7 +216,6 @@ export function noteOn(note, velocity = 1) {
     document.getElementById('vco2-led')?.classList.add('on');
     document.getElementById('vco3-led')?.classList.add('on');
     document.getElementById('master-led')?.classList.add('on');
-    startScope();
 }
 
 /**
@@ -238,6 +236,5 @@ export function noteOff(note) {
         document.getElementById('vco2-led')?.classList.remove('on');
         document.getElementById('vco3-led')?.classList.remove('on');
         document.getElementById('master-led')?.classList.remove('on');
-        stopScope();
     }
 }

--- a/js/ui/keyboard.js
+++ b/js/ui/keyboard.js
@@ -6,7 +6,6 @@ import { noteOn, noteOff } from '../audio/voice-manager.js';
 // Keyboard mapping constants
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 const BLACK_NOTES = [1, 3, 6, 8, 10]; // Indices of black keys in octave
-const WHITE_KEY_WIDTH = 28;
 const BASE_NOTE = 60; // C4
 
 // Base keyboard mapping (relative offsets from base note)
@@ -71,7 +70,8 @@ export function createKeyboard() {
 
         if (isBlack) {
             key.className = 'black-key';
-            key.style.left = `${whiteKeyIndex * WHITE_KEY_WIDTH - 9}px`;
+            // Position calculated after append, see below
+            key.dataset.whiteIndex = whiteKeyIndex;
         } else {
             key.className = 'white-key';
 
@@ -105,6 +105,15 @@ export function createKeyboard() {
 
         keyboard.appendChild(key);
     }
+
+    // Position black keys based on actual white key width
+    const firstWhite = keyboard.querySelector('.white-key');
+    const whiteW = firstWhite ? firstWhite.offsetWidth : 28;
+    const blackOffset = Math.round(whiteW * 0.32);
+    keyboard.querySelectorAll('.black-key').forEach(bk => {
+        const idx = parseInt(bk.dataset.whiteIndex);
+        bk.style.left = `${idx * whiteW - blackOffset}px`;
+    });
 
     // Initial label setup
     updateKeyboardLabels();

--- a/js/ui/visualizations.js
+++ b/js/ui/visualizations.js
@@ -2,26 +2,6 @@
 
 import { analyser } from '../state.js';
 
-let scopeAnimId = null;
-
-/**
- * Start the oscilloscope rendering loop (call when audio starts)
- */
-export function startScope() {
-    if (scopeAnimId !== null) return;
-    drawOscilloscope();
-}
-
-/**
- * Stop the oscilloscope rendering loop (call when all voices released)
- */
-export function stopScope() {
-    if (scopeAnimId !== null) {
-        cancelAnimationFrame(scopeAnimId);
-        scopeAnimId = null;
-    }
-}
-
 /**
  * Draw the oscilloscope waveform display
  */
@@ -37,7 +17,7 @@ export function drawOscilloscope() {
     let dataArray = null;
 
     function draw() {
-        scopeAnimId = requestAnimationFrame(draw);
+        requestAnimationFrame(draw);
 
         if (!analyser) return;
 

--- a/sw.js
+++ b/sw.js
@@ -40,6 +40,13 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
     event.respondWith(
-        caches.match(event.request).then((cached) => cached || fetch(event.request))
+        fetch(event.request)
+            .then((response) => {
+                // Update cache with fresh response
+                const clone = response.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+                return response;
+            })
+            .catch(() => caches.match(event.request))
     );
 });


### PR DESCRIPTION
## Summary
- **Mobile layout**: 2-column CSS grid for synth modules, compact knobs/buttons, hidden info panel
- **Keyboard responsive**: dynamic black key positioning based on actual white key width
- **Oscilloscope**: always-on like a real scope (continuous flat line when idle)
- **Service worker**: network-first strategy — always fetches fresh, falls back to cache offline

## Test plan
- [ ] Mobile (390px): modules in 2 columns, knobs usable, keyboard scrollable
- [ ] Desktop (1440px): layout unchanged
- [ ] Oscilloscope shows waveform while playing, flat line when idle
- [ ] CSS updates immediately on reload (no stale cache)
- [ ] Works offline after first load